### PR TITLE
show proper error message when saving query fails

### DIFF
--- a/extension/scripts/queryEditor/queryDialog.ts
+++ b/extension/scripts/queryEditor/queryDialog.ts
@@ -15,9 +15,14 @@ import * as SDK from "azure-devops-extension-sdk";
 
 
 
-export async function save(result?: any, query?: IQuery) {
+export async function handleSaveResult(result?: any, query?: IQuery, errMsg?: string) {
     const dialogService = await SDK.getService<IHostPageLayoutService>(CommonServiceIds.HostPageLayoutService);
     try {
+        //check if result is null or undefined and throw error
+    if (result === null || result === undefined) {
+        throw new Error("Failed to save query");
+    }
+       
     if (typeof result !== "string") {
         return;
     }
@@ -27,13 +32,13 @@ export async function save(result?: any, query?: IQuery) {
     } else {
         navigationService.navigate(result);
     }
-} catch (error) {
-    const message = saveErrorMessage(error, query);
-    dialogService.openMessageDialog(message, {
-        title: "Error saving query",
-    });
-   
-}
+    } catch (error) {
+        // if errMsg is not null or undefined use errMsg in saveErrorMessage function otherwise use error as parameter
+        const message = saveErrorMessage(errMsg || error, query);
+        dialogService.openMessageDialog(message, {
+            title: "Error saving query",
+        });
+    }
 }
 
 

--- a/extension/scripts/queryEditor/queryEditor.ts
+++ b/extension/scripts/queryEditor/queryEditor.ts
@@ -2,7 +2,7 @@ import * as SDK from "azure-devops-extension-sdk";
 import "promise-polyfill/src/polyfill";
 import { setupEditor } from "../wiqlEditor/wiqlEditor";
 import * as monaco from "monaco-editor";
-import {save} from "../queryEditor/queryDialog";
+import {handleSaveResult} from "../queryEditor/queryDialog";
 
 
 
@@ -20,7 +20,7 @@ SDK.init().then(() => {
         label: "Save",
         keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_S],
         run: () => {
-            save();
+            handleSaveResult();
             return null as any;
         },
     });


### PR DESCRIPTION
This pull request includes modifications to improve the functionality and maintainability of the codebase. The most important changes include replacing function calls and modifying return types in multiple files related to the query editor.

Main changes:

* <a href="diffhunk://#diff-e2c981e2513b69149574299ee158395b1d96d35ddc83e9b1786df749e30891efL138-L147">`extension/scripts/wiqlEditor/importExport.ts`</a>: Modified the `saveQuery` function to replace the `save` function call with the `handleSaveResult` function call and changed the return type. <a href="diffhunk://#diff-e2c981e2513b69149574299ee158395b1d96d35ddc83e9b1786df749e30891efL138-L147">[1]</a> <a href="diffhunk://#diff-e2c981e2513b69149574299ee158395b1d96d35ddc83e9b1786df749e30891efL105-R105">[2]</a>
* <a href="diffhunk://#diff-361615128d390fed4ed2acb03e06bf9a1bb5a9b272d99e6633600d50f3293f3cL31-L35">`extension/scripts/queryEditor/queryDialog.ts`</a>: Added a comment and refactored a function call in the `save` function, and added a check for `result` being `null` or `undefined` and throwing an error in the `handleSaveResult` function. <a href="diffhunk://#diff-361615128d390fed4ed2acb03e06bf9a1bb5a9b272d99e6633600d50f3293f3cL31-L35">[1]</a> <a href="diffhunk://#diff-361615128d390fed4ed2acb03e06bf9a1bb5a9b272d99e6633600d50f3293f3cL18-R25">[2]</a>
* <a href="diffhunk://#diff-62b658fd8cd84b1bb985819e5ccf18fabf87fd194900617eb8432bc993eeb344L5-R5">`extension/scripts/queryEditor/queryEditor.ts`</a>: Replaced the `save` import statement and function call with `handleSaveResult`. <a href="diffhunk://#diff-62b658fd8cd84b1bb985819e5ccf18fabf87fd194900617eb8432bc993eeb344L5-R5">[1]</a> <a href="diffhunk://#diff-62b658fd8cd84b1bb985819e5ccf18fabf87fd194900617eb8432bc993eeb344L23-R23">[2]</a>